### PR TITLE
add message object to abstract mail gem interactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ GMAIL = Mailthis.mailer do
   logger    Logger.new("log/email.log") # (optional) default: no logger, no logging
 end
 
-msg = Mail.new
+msg = Mailthis::Message.new
 msg.from     = 'bob@example.com',       # (optional) default: mailer #from
 msg.reply_to = 'bob@me.com',            # (optional) default: self #from
 msg.to       = "you@example.com",

--- a/lib/mailthis.rb
+++ b/lib/mailthis.rb
@@ -1,5 +1,6 @@
 require 'mailthis/version'
 require 'mailthis/exceptions'
+require 'mailthis/message'
 require 'mailthis/mailer'
 
 module Mailthis

--- a/lib/mailthis/mailer.rb
+++ b/lib/mailthis/mailer.rb
@@ -1,6 +1,6 @@
 require 'ns-options/proxy'
-require 'mail'
 require 'mailthis/exceptions'
+require 'mailthis/message'
 require 'mailthis/outgoing_email'
 
 module Mailthis
@@ -32,7 +32,7 @@ module Mailthis
     end
 
     def deliver(message = nil, &block)
-      (message || ::Mail.new).tap do |msg|
+      (message || ::Mailthis::Message.new).tap do |msg|
         msg.instance_eval(&block) if block
         OutgoingEmail.new(self, msg).deliver
       end

--- a/lib/mailthis/message.rb
+++ b/lib/mailthis/message.rb
@@ -1,0 +1,33 @@
+require 'mail'
+
+module Mailthis
+
+  class Message
+
+    def initialize
+      @mail = ::Mail.new
+    end
+
+    def from(*args);     @mail.from(*args);     end
+    def reply_to(*args); @mail.reply_to(*args); end
+    def to(*args);       @mail.to(*args);       end
+    def cc(*args);       @mail.cc(*args);       end
+    def bcc(*args);      @mail.bcc(*args);      end
+    def subject(*args);  @mail.subject(*args);  end
+    def body(*args);     @mail.body(*args);     end
+
+    def from=(value);     @mail.from     = value; end
+    def reply_to=(value); @mail.reply_to = value; end
+    def to=(value);       @mail.to       = value; end
+    def cc=(value);       @mail.cc       = value; end
+    def bcc=(value);      @mail.bcc      = value; end
+    def subject=(value);  @mail.subject  = value; end
+    def body=(value);     @mail.body     = value; end
+
+    def to_s
+      @mail.to_s
+    end
+
+  end
+
+end

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -17,13 +17,13 @@ module Factory
   end
 
   def self.message(settings = nil)
-    require 'mail'
-    message = Mail.new do
-      to      'you@example.com'
-      subject 'a message'
-    end
+    require 'mailthis/message'
+    message = Mailthis::Message.new
+    message.to      'you@example.com'
+    message.subject 'a message'
+
     (settings || {}).inject(message) do |msg, (setting, value)|
-      msg[setting] = value
+      msg.send("#{setting}=", value)
       msg
     end
   end

--- a/test/unit/mailer_tests.rb
+++ b/test/unit/mailer_tests.rb
@@ -2,6 +2,7 @@ require 'assert'
 require 'mailthis/mailer'
 
 require 'mailthis/exceptions'
+require 'mailthis/message'
 
 class Mailthis::Mailer
 
@@ -159,7 +160,7 @@ class Mailthis::Mailer
         subject 'a message'
       end
 
-      assert_kind_of ::Mail::Message, built_msg
+      assert_kind_of Mailthis::Message, built_msg
       assert_equal ['me@example.com'], built_msg.from
       assert_equal ['you@example.com'], built_msg.to
       assert_equal 'a message', built_msg.subject
@@ -170,7 +171,7 @@ class Mailthis::Mailer
         from 'me@example.com'
       end
 
-      assert_kind_of ::Mail::Message, built_msg
+      assert_kind_of Mailthis::Message, built_msg
       assert_equal ['me@example.com'], built_msg.from
       assert_equal ['you@example.com'], built_msg.to
       assert_equal 'a message', built_msg.subject

--- a/test/unit/message_tests.rb
+++ b/test/unit/message_tests.rb
@@ -1,0 +1,82 @@
+require 'assert'
+require 'mailthis/message'
+
+require 'mail'
+
+class Mailthis::Message
+
+  class UnitTests < Assert::Context
+    desc "Mailthis::Message"
+    setup do
+      @from     = Factory.email
+      @reply_to = Factory.email
+      @to       = Factory.email
+      @cc       = Factory.email
+      @bcc      = Factory.email
+      @subject  = Factory.string
+      @body     = Factory.text
+
+      @mail = ::Mail.new
+      Assert.stub(::Mail, :new){ @mail }
+
+      @message = Mailthis::Message.new
+    end
+    subject{ @message }
+
+    should have_imeths :from, :reply_to, :to, :cc, :bcc, :subject, :body
+    should have_imeths :from=, :reply_to=, :to=, :cc=, :bcc=, :subject=, :body=
+    should have_imeths :to_s
+
+    should "use Mail's default attrs" do
+      assert_equal @mail.from,      subject.from
+      assert_equal @mail.reply_to,  subject.reply_to
+      assert_equal @mail.to,        subject.to
+      assert_equal @mail.cc,        subject.cc
+      assert_equal @mail.bcc,       subject.bcc
+      assert_equal @mail.subject,   subject.subject
+      assert_equal @mail.body.to_s, subject.body.to_s
+    end
+
+    should "write attrs with traditional writers" do
+      subject.from     = @from
+      subject.reply_to = @reply_to
+      subject.to       = @to
+      subject.cc       = @cc
+      subject.bcc      = @bcc
+      subject.subject  = @subject
+      subject.body     = @body
+
+      assert_equal [@from],     subject.from
+      assert_equal [@reply_to], subject.reply_to
+      assert_equal [@to],       subject.to
+      assert_equal [@cc],       subject.cc
+      assert_equal [@bcc],      subject.bcc
+      assert_equal @subject,    subject.subject
+      assert_equal @body,       subject.body.to_s
+    end
+
+    should "write attrs using DSL methods" do
+      subject.from     @from
+      subject.reply_to @reply_to
+      subject.to       @to
+      subject.cc       @cc
+      subject.bcc      @bcc
+      subject.subject  @subject
+      subject.body     @body
+
+      assert_equal [@from],     subject.from
+      assert_equal [@reply_to], subject.reply_to
+      assert_equal [@to],       subject.to
+      assert_equal [@cc],       subject.cc
+      assert_equal [@bcc],      subject.bcc
+      assert_equal @subject,    subject.subject
+      assert_equal @body,       subject.body.to_s
+    end
+
+    should "know its string representation" do
+      assert_equal @mail.to_s, subject.to_s
+    end
+
+  end
+
+end

--- a/test/unit/outgoing_email_tests.rb
+++ b/test/unit/outgoing_email_tests.rb
@@ -34,22 +34,17 @@ class Mailthis::OutgoingEmail
       assert_equal subject.message.from, subject.message.reply_to
     end
 
+    should "complain if given an invalid message" do
+      assert_raises(Mailthis::MessageError) do
+        Mailthis::OutgoingEmail.new(@mailer, 'invalid-msg')
+      end
+    end
+
     should "complain if delivering with an invalid mailer" do
       @mailer.smtp_server = nil
       assert_not @mailer.valid?
 
-      assert_raises(Mailthis::MailerError) do
-        subject.deliver
-      end
-    end
-
-    should "complain if delivering an invalid message" do
-      msg = Factory.message
-      msg.to = nil
-
-      assert_raises(Mailthis::MessageError) do
-        Mailthis::OutgoingEmail.new(@mailer, msg).deliver
-      end
+      assert_raises(Mailthis::MailerError){ subject.deliver }
     end
 
     should "log when delivering a message" do
@@ -83,13 +78,14 @@ class Mailthis::OutgoingEmail
     should "complain if the message is missing required fields" do
       msg = Factory.message
       msg.subject = nil
+
       assert_invalid_with msg
     end
 
     should "complain if the message is not addressed to anyone" do
       msg = Factory.message
-
       msg.to = msg.cc = msg.bcc = nil
+
       assert_invalid_with msg
     end
 


### PR DESCRIPTION
Mailthis is essentially only using the mail gem for it's message
API and for building the message string to send using `Net::SMTP`.
The previous implementation used the `::Mail` object directly.  This
switches to abstracting the mail interactions via a message class.

We really only need a small subset of mails capabilities and this
enforces that.  It also establishes a spec for what a mailthis
message needs to do.  Finally, this implementation more easily allows
for switching out the mail gem for a better alternative when/if
one arises.

Note: this also cleans up some of things about the outgoing email's
implementation.  These are mostly just cleanups and attempts at
keeping the implementation easy to follow and comprehend.

Overall, no behavior changes.

@jcredding ready for review.