### PR TITLE
remove ns-options as a dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,4 @@ gemspec
 gem 'pry', "~> 0.9.0"
 
 # mail dependencies that are 1.8.7 compatible
-gem 'mime-types', "=1.25.1"
+gem 'mime-types', "= 1.25.1"

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ GMAIL = Mailthis.mailer do
   smtp_pw     'secret'
 
   smtp_auth "plain"                     # (optional) default: "login"
-  from      "me@example.com"            # (optional) default: config.smtp_username (if valid)
+  from      "me@example.com"            # (optional) default: `smtp_user` (if valid)
   logger    Logger.new("log/email.log") # (optional) default: no logger, no logging
 end
 

--- a/mailthis.gemspec
+++ b/mailthis.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency("assert", ["~> 2.15.1"])
 
-  gem.add_dependency("ns-options", ["~> 1.1.6"])
-  gem.add_dependency("mail",       ["~> 2.5"])
+  gem.add_dependency("much-plugin", ["~> 0.2.0"])
+  gem.add_dependency("mail",        ["~> 2.5"])
 
 end

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -3,16 +3,18 @@ require 'assert/factory'
 module Factory
   extend Assert::Factory
 
-  def self.mailer
+  def self.mailer(s = {})
+    s ||= {}
     require 'mailthis/mailer'
     Mailthis::Mailer.new do
-      smtp_helo   "example.com"
-      smtp_server "smtp.example.com"
-      smtp_port   25
-      smtp_user   "test@example.com"
-      smtp_pw     "secret"
-      smtp_auth   :plain
-      from        "me@example.com"
+      smtp_helo   (s.key?(:smtp_helo)   ? s[:smtp_helo]   : "example.com")
+      smtp_server (s.key?(:smtp_server) ? s[:smtp_server] : "smtp.example.com")
+      smtp_port   (s.key?(:smtp_port)   ? s[:smtp_port]   : 25)
+      smtp_user   (s.key?(:smtp_user)   ? s[:smtp_user]   : "test@example.com")
+      smtp_pw     (s.key?(:smtp_pw)     ? s[:smtp_pw]     : "secret")
+      smtp_auth   (s.key?(:smtp_auth)   ? s[:smtp_auth]   : :plain)
+      from        (s.key?(:from)        ? s[:from]        : "me@example.com")
+      logger      (s.key?(:logger)      ? s[:logger]      : nil)
     end
   end
 

--- a/test/unit/mailer_tests.rb
+++ b/test/unit/mailer_tests.rb
@@ -19,6 +19,24 @@ module Mailthis::Mailer
 
     should have_imeths :new
 
+    should "know its required settings" do
+     exp = [
+       :smtp_helo,
+       :smtp_server,
+       :smtp_port,
+       :smtp_user,
+       :smtp_pw,
+       :smtp_auth,
+       :from,
+       :logger
+     ]
+     assert_equal exp, subject::REQUIRED_SETTINGS
+    end
+
+    should "know its default auth value" do
+      assert_equal 'login', subject::DEFAULT_AUTH
+    end
+
     should "return a mailthis mailer using `new`" do
       ENV.delete('MAILTHIS_TEST_MODE')
       mailer = subject.new
@@ -45,9 +63,9 @@ module Mailthis::Mailer
     should have_imeths :smtp_helo, :smtp_server, :smtp_port
     should have_imeths :smtp_user, :smtp_pw, :smtp_auth
     should have_imeths :from, :logger
-    should have_imeths :validate!, :deliver
+    should have_imeths :valid?, :validate!, :deliver
 
-    should "know its smtp settings" do
+    should "know its smtp helo, server, port and user settings" do
       { :smtp_helo   => Factory.string,
         :smtp_server => Factory.string,
         :smtp_port   => Factory.integer,
@@ -61,27 +79,124 @@ module Mailthis::Mailer
       end
     end
 
-    should "use `\"login\"` as the auth by default" do
-      assert_equal "login", subject.smtp_auth
+    should "know its smtp auth setting" do
+      assert_equal DEFAULT_AUTH, subject.smtp_auth
 
-      subject.smtp_auth 'plain'
-      assert_equal 'plain', subject.smtp_auth
+      exp = Factory.string
+      subject.smtp_auth exp
+      assert_equal exp, subject.smtp_auth
     end
 
-    should "use the smtp user as the from by default" do
+    should "know its from setting" do
       assert_nil subject.from
 
-      subject.smtp_user 'user'
-      assert_equal 'user', subject.from
+      exp = Factory.email
+      subject.from exp
+      assert_equal exp, subject.from
     end
 
-    should "allow overriding the from" do
-      subject.from 'a-user'
-      assert_equal 'a-user', subject.from
+    should "know its logger setting" do
+      assert_instance_of NullLogger, subject.logger
+
+      exp = Factory.string
+      subject.logger exp
+      assert_equal exp, subject.logger
     end
 
-    should "use a null logger by default" do
-      assert_kind_of Mailthis::Mailer::NullLogger, subject.logger
+  end
+
+  class ValidationTests < UnitTests
+    desc "when validating"
+    setup do
+      @valid_settings = {
+        :smtp_helo   => Factory.string,
+        :smtp_server => Factory.string,
+        :smtp_port   => Factory.integer,
+        :smtp_user   => Factory.email,
+        :smtp_pw     => Factory.string,
+        :smtp_auth   => :plain,
+        :from        => nil
+      }
+      @valid_mailer = Factory.mailer(@valid_settings)
+    end
+    subject{ @valid_mailer }
+
+    should "not be valid until validated" do
+      assert_false subject.valid?
+      subject.validate!
+      assert_true subject.valid?
+    end
+
+    should "not complain if all settings are in place" do
+      assert_valid(subject)
+    end
+
+    should "return itself when validating" do
+      assert_same subject, subject.validate!
+    end
+
+    should "set the from to the smtp user if it isn't set already" do
+      assert_nil subject.from
+
+      subject.validate!
+      assert_equal subject.smtp_user, subject.from
+    end
+
+    should "be invalid if no helo domain is set" do
+      @valid_settings[:smtp_helo] = nil
+      assert_invalid(Factory.mailer(@valid_settings))
+    end
+
+    should "be invalid if no server is set" do
+      @valid_settings[:smtp_server] = nil
+      assert_invalid(Factory.mailer(@valid_settings))
+    end
+
+    should "be invalid if no port is set" do
+      @valid_settings[:smtp_port] = nil
+      assert_invalid(Factory.mailer(@valid_settings))
+    end
+
+    should "be invalid if no user is set" do
+      @valid_settings[:smtp_user] = nil
+      assert_invalid(Factory.mailer(@valid_settings))
+    end
+
+    should "be invalid if no pw is set" do
+      @valid_settings[:smtp_pw] = nil
+      assert_invalid(Factory.mailer(@valid_settings))
+    end
+
+    should "not be invalid if no auth is set" do
+      # b/c it has a default value
+      @valid_settings[:smtp_auth] = nil
+      assert_valid(Factory.mailer(@valid_settings))
+    end
+
+    should "not be invalid if no from is set" do
+      # b/c it is defaulted from the smtp user
+      @valid_settings[:from] = nil
+      assert_valid(Factory.mailer(@valid_settings))
+    end
+
+    should "not be invalid if no logger is set" do
+      # b/c it is defaulted to a NullLogger
+      @valid_settings[:logger] = nil
+      assert_valid(Factory.mailer(@valid_settings))
+    end
+
+    private
+
+    def assert_valid(mailer)
+      with_backtrace(caller) do
+        assert_nothing_raised{ mailer.validate! }
+      end
+    end
+
+    def assert_invalid(mailer)
+      with_backtrace(caller) do
+        assert_raises(Mailthis::MailerError){ mailer.validate! }
+      end
     end
 
   end
@@ -91,7 +206,7 @@ module Mailthis::Mailer
     setup do
       @message = Factory.message(:from => "me@example.com")
       @mailer  = Factory.mailer
-      @mailer.logger = Factory.logger(@out = "")
+      @mailer.logger(Factory.logger(@out = ""))
 
       @sent_msg = @mailer.deliver(@message)
     end
@@ -117,7 +232,7 @@ module Mailthis::Mailer
       assert_equal 'a message', built_msg.subject
     end
 
-    should "task a message and apply the given block" do
+    should "take a message and apply the given block" do
       built_msg = @mailer.deliver(Factory.message) do
         from 'me@example.com'
       end
@@ -126,84 +241,6 @@ module Mailthis::Mailer
       assert_equal ['me@example.com'], built_msg.from
       assert_equal ['you@example.com'], built_msg.to
       assert_equal 'a message', built_msg.subject
-    end
-
-  end
-
-  class ValidationTests < UnitTests
-    desc "when validating"
-    setup do
-      @invalid = Mailthis::Mailer.new do
-        smtp_helo   Factory.string
-        smtp_server Factory.string
-        smtp_port   Factory.integer
-        smtp_user   Factory.email
-        smtp_pw     Factory.string
-        smtp_auth   :plain
-      end
-    end
-    subject{ @invalid }
-
-    should "not complain if all settings are in place" do
-      assert_valid
-    end
-
-    should "return itself when validating" do
-      assert_same subject, subject.validate!
-    end
-
-    should "be invalid if missing the helo domain" do
-      subject.smtp_helo = nil
-      assert_invalid
-    end
-
-    should "be invalid if missing the server" do
-      subject.smtp_server = nil
-      assert_invalid
-    end
-
-    should "be invalid if missing the port" do
-      subject.smtp_port = nil
-      assert_invalid
-    end
-
-    should "be invalid if missing the user" do
-      subject.smtp_user = nil
-      assert_invalid
-    end
-
-    should "be invalid if missing the pw" do
-      subject.smtp_pw = nil
-      assert_invalid
-    end
-
-    should "be invalid if missing the auth" do
-      subject.smtp_auth = nil
-      assert_invalid
-    end
-
-    should "be invalid if missing the from" do
-      subject.from = nil
-      assert_invalid
-    end
-
-    should "be invalid if missing the logger" do
-      subject.logger = nil
-      assert_invalid
-    end
-
-    private
-
-    def assert_valid
-      assert_nothing_raised do
-        subject.validate!
-      end
-    end
-
-    def assert_invalid
-      assert_raises(Mailthis::MailerError) do
-        subject.validate!
-      end
     end
 
   end

--- a/test/unit/outgoing_email_tests.rb
+++ b/test/unit/outgoing_email_tests.rb
@@ -41,17 +41,19 @@ class Mailthis::OutgoingEmail
     end
 
     should "complain if delivering with an invalid mailer" do
-      @mailer.smtp_server = nil
-      assert_not @mailer.valid?
+      mailer = Factory.mailer(:smtp_server => nil)
+      assert_false mailer.valid?
 
-      assert_raises(Mailthis::MailerError){ subject.deliver }
+      email  = Mailthis::OutgoingEmail.new(mailer, @message)
+      assert_raises(Mailthis::MailerError){ email.deliver }
     end
 
     should "log when delivering a message" do
-      @mailer.logger = Factory.logger(out = "")
+      mailer = Factory.mailer(:logger => Factory.logger(out = ""))
       assert_empty out
 
-      subject.deliver
+      email  = Mailthis::OutgoingEmail.new(mailer, @message)
+      email.deliver
 
       assert_not_empty out
       assert_includes "Sent '#{@message.subject}'", out


### PR DESCRIPTION
This is part of getting this gem working in modern ruby versions.
We are moving away from using ns-options as a dependency b/c it
has performance issues when accessing options and on top of that
its API hasn't proven to be especially useful over a struct-like
class.

This switches the mailer's settings to be set manually by a DSL
method for each setting.  This includes honoring the previous
defaulting logic for `smtp_auth`, `from` and `logger`.  This also
manually implements the `valid?` and  `validate!` logic.  Note:
there are some backwards-incompatible changes here, specifically
you can't no longer build mailers given a hash of options and
you can't set option values to procs for lazy-eval.  These were
features previously provided by ns-options.  You also can't eet
options to `nil` values like you could before.

I did a bunch of reworks to the mailer tests, mostly related to
not being able to set individual settings to `nil` and the 
manual defaulting logic.  This involved updating the mailer
factory to take a hash of settings whiched helped in creating
the necessary mailers for these tests.  A few other tests were
modified as needed as well.

Finally, this brings in much-plugin to ensure the mailer mixin
logic is only applied once.

@jcredding ready for review.